### PR TITLE
Extract 'Extensibility of the API'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ navigator.share({title: 'Example Page', url: 'https://example.com'});
 * [Web platform
   tests](https://github.com/w3c/web-platform-tests/tree/master/web-share), for
   automatic and manual testing against an implementation.
+* [Extensibility of the Web Share API](https://wicg.github.io/web-share/extending.html).
 
 This is a product of the [Ballista
 project](https://github.com/chromium/ballista), which aims to explore

--- a/extending.html
+++ b/extending.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>
+      Extending the Web Share API
+    </title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class=
+    "remove"></script>
+  </head>
+  <body>
+    <section style="display:none;">
+      <h2>
+        Dependencies
+      </h2>
+      <p>
+        <code><dfn data-cite=
+        "!ECMASCRIPT#sec-native-error-types-used-in-this-standard-typeerror">TypeError</dfn></code>
+        is defined by [[!ECMASCRIPT]].
+      </p>
+    </section>
+    <section class="appendix informative">
+      <h2>
+        Extending the Web Share API
+      </h2>
+      <p>
+        The Web Share API is designed to be extended in the future by way of
+        new members added to the
+        <a href="https://wicg.github.io/web-share/#sharedata-dictionary">ShareData</a>
+        dictionary, to allow both
+        sharing of new types of data (<i>e.g.</i>, <a href=
+        "https://github.com/WICG/web-share/issues/12">images</a>) and strings
+        with new semantics (<i>e.g.</i> author).
+      </p>
+      <div class="warning">
+        This doesn't mean user agents can add whatever members they like. It
+        means that new members can be added to the standard in the future.
+      </div>
+      <p data-link-for="ShareData">
+        The three members <a href="https://wicg.github.io/web-share/#dom-sharedata-title">title</a>,
+        <a href="https://wicg.github.io/web-share/#dom-sharedata-text">text</a>,
+        and <a href="https://wicg.github.io/web-share/#dom-sharedata-url">url</a>, are part
+        of the base feature set, and implementations that provide
+        <a href="https://wicg.github.io/web-share/#dom-navigator-share">navigator.share()</a>
+        need to accept all three. Any new members that
+        are added in the future will be <em>individually
+        feature-detectable</em>, to allow for backwards-compatibility with
+        older implementations that don't recognize those members. These new
+        members might also be added as optional "MAY" requirements.
+      </p>
+      <div class="note">
+        There is <a href="https://github.com/heycam/webidl/issues/107">an open
+        discussion</a> about how to provide feature-detection for dictionary
+        members. Web Share will use the mechanism produced by that discussion.
+      </div>
+      <p data-link-for="Navigator">
+        The <a href="https://wicg.github.io/web-share/#dom-navigator-share">share()</a>
+        method returns a rejected promise
+        with a <a>TypeError</a> if none of the
+        specified members are present. The intention is that when a new member
+        is added, it will also be added to this list of recognized members.
+        This is for future-proofing implementations:
+        if a web site written against a future version of this spec uses
+        <em>only</em> new members (<i>e.g.</i>, <code>navigator.share({image:
+        x})</code>), it will be valid in future user agents, but a
+        <a>TypeError</a> on user agents implementing an older version of the
+        spec. Developers will be asked to feature-detect any new fields they
+        rely on, to avoid having errors surface in their program.
+      </p>
+      <p>
+        Editors of this spec will want to carefully consider the genericity of
+        any new members being added, avoiding fields that are closely
+        associated with a particular service, user agent or operating system,
+        in favour of fields that can potentially be applied to a wide range of
+        platforms and targets.
+      </p>
+    </section>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -421,56 +421,6 @@
         </li>
       </ul>
     </section>
-    <section class="appendix informative">
-      <h2>
-        Extensibility of this API
-      </h2>
-      <p>
-        The Web Share API is designed to be extended in the future by way of
-        new members added to the <a>ShareData</a> dictionary, to allow both
-        sharing of new types of data (<i>e.g.</i>, <a href=
-        "https://github.com/WICG/web-share/issues/12">images</a>) and strings
-        with new semantics (<i>e.g.</i> author).
-      </p>
-      <div class="warning">
-        This doesn't mean user agents can add whatever members they like. It
-        means that new members can be added to the standard in the future.
-      </div>
-      <p data-link-for="ShareData">
-        The three members <a>title</a>, <a>text</a>, and <a>url</a>, are part
-        of the base feature set, and implementations that provide
-        <a>navigator.share()</a> need to accept all three. Any new members that
-        are added in the future will be <em>individually
-        feature-detectable</em>, to allow for backwards-compatibility with
-        older implementations that don't recognize those members. These new
-        members might also be added as optional "MAY" requirements.
-      </p>
-      <div class="note">
-        There is <a href="https://github.com/heycam/webidl/issues/107">an open
-        discussion</a> about how to provide feature-detection for dictionary
-        members. Web Share will use the mechanism produced by that discussion.
-      </div>
-      <p data-link-for="Navigator">
-        The <a>share()</a> method returns a rejected promise
-        with a <a>TypeError</a> if none of the
-        specified members are present. The intention is that when a new member
-        is added, it will also be added to this list of recognized members.
-        This is for future-proofing implementations:
-        if a web site written against a future version of this spec uses
-        <em>only</em> new members (<i>e.g.</i>, <code>navigator.share({image:
-        x})</code>), it will be valid in future user agents, but a
-        <a>TypeError</a> on user agents implementing an older version of the
-        spec. Developers will be asked to feature-detect any new fields they
-        rely on, to avoid having errors surface in their program.
-      </p>
-      <p>
-        Editors of this spec will want to carefully consider the genericity of
-        any new members being added, avoiding fields that are closely
-        associated with a particular service, user agent or operating system,
-        in favour of fields that can potentially be applied to a wide range of
-        platforms and targets.
-      </p>
-    </section>
     <section class="appendix">
       <h2>
         Acknowledgments


### PR DESCRIPTION
The chapter 'Extensibility of the API' is moved into a separate
document. It remains available as a resource for informing future
evolution of the specification, without itself being part of the
specification.

resolves #61


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share/pull/72.html" title="Last updated on Feb 20, 2018, 3:14 AM GMT (5214ef1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share/72/62ffe50...ewilligers:5214ef1.html" title="Last updated on Feb 20, 2018, 3:14 AM GMT (5214ef1)">Diff</a>