### PR TITLE
s/wicg/w3c/

### DIFF
--- a/level-2/index.html
+++ b/level-2/index.html
@@ -360,7 +360,7 @@
         <div class="note">
           There is an attempt to standardize the registration of websites to
           receive share data for that final use case; see <a href=
-          "https://github.com/w3c/web-share-target">Web Share Target</a>.
+          "https://github.com/WICG/web-share-target">Web Share Target</a>.
         </div>
         <p>
           In some cases, the host operating system will provide a sharing or

--- a/level-2/index.html
+++ b/level-2/index.html
@@ -10,9 +10,9 @@
     <script class='remove'>
       var respecConfig = {
         specStatus: "CG-DRAFT",
-        edDraftURI: "https://wicg.github.io/web-share/level-2/",
+        edDraftURI: "https://w3c.github.io/web-share/level-2/",
         github: {
-          repoURL: "https://github.com/WICG/web-share/",
+          repoURL: "https://github.com/w3c/web-share/",
           branch: "master"
         },
         testSuiteURI: "https://w3c-test.org/web-share/",
@@ -360,7 +360,7 @@
         <div class="note">
           There is an attempt to standardize the registration of websites to
           receive share data for that final use case; see <a href=
-          "https://github.com/WICG/web-share-target">Web Share Target</a>.
+          "https://github.com/w3c/web-share-target">Web Share Target</a>.
         </div>
         <p>
           In some cases, the host operating system will provide a sharing or
@@ -465,7 +465,7 @@
         The Web Share API is designed to be extended in the future by way of
         new members added to the <a>ShareData</a> dictionary, to allow both
         sharing of new types of data (<i>e.g.</i>, <a href=
-        "https://github.com/WICG/web-share/issues/12">images</a>) and strings
+        "https://github.com/w3c/web-share/issues/12">images</a>) and strings
         with new semantics (<i>e.g.</i> author).
       </p>
       <div class="warning">


### PR DESCRIPTION
Correct links to point to w3c repo instead of the WICG one.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomayac/web-share/pull/122.html" title="Last updated on Sep 5, 2019, 7:07 AM UTC (b1a8e86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/122/e0e41f2...tomayac:b1a8e86.html" title="Last updated on Sep 5, 2019, 7:07 AM UTC (b1a8e86)">Diff</a>