### PR TITLE
Clarify that UAs can concatenate fields like on Android.

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
         of the payload is at the discretion of the share target.
       </p>
       <div class="note">
-        Mapping the {{ShareData}} to the share target (or operating system)'s
+        Mapping the {{ShareData}} to the share target's (or operating system's)
         native format can be tricky as some platforms will not have an
         equivalent set of members. For example, if the target has a "text"
         member but not a "URL" member (as is the case on Android), one solution

--- a/index.html
+++ b/index.html
@@ -301,9 +301,18 @@
         concepts exposed in {{ShareData}}. To <dfn>convert data to a format
         suitable for ingestion into the target</dfn>, the user agent SHOULD map
         the members of {{ShareData}} onto equivalent concepts in the target. It
-        MAY discard members if necessary. The meaning of each member of the
-        payload is at the discretion of the share target.
+        MAY discard or combine members if necessary. The meaning of each member
+        of the payload is at the discretion of the share target.
       </p>
+      <div class="note">
+        Mapping the {{ShareData}} to the share target (or operating system)'s
+        native format can be tricky as some platforms will not have an
+        equivalent set of members. For example, if the target has a "text"
+        member but not a "URL" member (as is the case on Android), one solution
+        is to concatenate both the {{ShareData/text}} and {{ShareData/url}}
+        members of {{ShareData}} and pass the result in the "text" member of
+        the target.
+      </div>
       <p>
         Each share target MAY be made conditionally available depending on the
         {{ShareData}} payload delivered to the {{Navigator/share()}} method.
@@ -347,14 +356,6 @@
           intent system similar to Web Share. In these cases, the user agent
           can simply forward the share data to the operating system and not
           talk directly to native applications.
-        </p>
-        <p>
-          Mapping the {{ShareData}} to the share target (or operating system)'s
-          native format can be tricky as some platforms will not have an
-          equivalent set of members. For example, if the target has a "text"
-          member but not a "URL" member, one solution is to concatenate both
-          the {{ShareData/text}} and {{ShareData/url}} members of {{ShareData}}
-          and pass the result in the "text" member of the target.
         </p>
       </section>
     </section>


### PR DESCRIPTION
Moved the non-normative explanation out of the Examples section into
the Share targets section, and also addded normative directive that user
agents may discard *or combine* members (emphasis on the new text).

Closes #130.