### PR TITLE
Editorial: Use new HTML activation model

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,9 +156,9 @@
                 </li>
               </ol>
             </li>
-            <li>If the method call was not <a>triggered by user activation</a>,
-            return <a>a promise rejected with</a> with a {{"NotAllowedError"}}
-            {{DOMException}}.
+            <li>If the [=relevant global object=] of [=this=] does not have
+            [=transient activation=], return <a>a promise rejected with</a>
+            with a {{"NotAllowedError"}} {{DOMException}}.
             </li>
             <li>Set {{[[sharePromise]]}} to be <a>a new promise</a>.
             </li>


### PR DESCRIPTION
This is refactor to use HTML's new activation model. The api currently uses transient activation.

Details: https://github.com/whatwg/html/issues/5129 

In a new issue, we need to discuss if calling share should "consume" the activation.

Doing so might have the nice effect that we can get rid of the internal slot we added to protect against being able to call `.share()` twice during the same activation phase.  