### PR TITLE
BREAKING CHANGE: make share() consume user activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,11 +443,6 @@
         guard against this, but implementors will want to be aware that it is a
         possibility.
         </li>
-        <li>To prevent multiple share UIs from being displayed simultaneously,
-        as well as to mitigate some other behavior that could confuse end
-        users, calling {{Navigator/share()}} [=consume user activation|consumes
-        the user activation=] of the relevant {{Window}}.
-        </li>
       </ul>
     </section>
     <section class="appendix informative">

--- a/index.html
+++ b/index.html
@@ -170,10 +170,9 @@
                 </li>
               </ol>
             </li>
-            <li>If the [=relevant global object=] of [=this=] does not have
-            [=transient activation=], or a file type is being blocked due to
-            security considerations, return <a>a promise rejected with</a> with
-            a {{"NotAllowedError"}} {{DOMException}}.
+            <li>If a file type is being blocked due to security considerations,
+            return <a>a promise rejected with</a> with a {{"NotAllowedError"}}
+            {{DOMException}}.
             </li>
             <li>Set {{[[sharePromise]]}} to be <a>a new promise</a>.
             </li>

--- a/index.html
+++ b/index.html
@@ -137,6 +137,14 @@
             |data:ShareData|, run the following steps:
           </p>
           <ol class="algorithm">
+            <li>Let |window| be [=relevant global object=] of [=this=].
+            </li>
+            <li>If |window| does not have [=transient activation=], return [=a
+            promise rejected with=] with a {{"NotAllowedError"}}
+            {{DOMException}}.
+            </li>
+            <li>[=Consume user activation=] of |window|.
+            </li>
             <li>If {{[[sharePromise]]}} is not `null`, return <a>a promise
             rejected with</a> {{InvalidStateError}}.
             </li>
@@ -434,6 +442,11 @@
         native applications that receive shares. There is no general way to
         guard against this, but implementors will want to be aware that it is a
         possibility.
+        </li>
+        <li>To prevent multiple share UIs from being displayed simultaneously,
+        as well as to mitigate some other behavior that could confuse end
+        users, calling {{Navigator/share()}} [=consume user activation|consumes
+        the user activation=] of the relevant {{Window}}.
         </li>
       </ul>
     </section>


### PR DESCRIPTION
Closes #136 

For *normative* changes, the following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1083037)
 * [ ] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1643205)
