### PR TITLE
chore: 'present' xref does not exist

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,8 +144,7 @@
             {{ShareData/text}}, or {{ShareData/url}} are present, return <a>a
             promise rejected with</a> a {{TypeError}}.
             </li>
-            <li>If |data|'s {{ShareData/url}} member is [=dictionary
-            member/present=]:
+            <li>If |data|'s {{ShareData/url}} member is present:
               <ol>
                 <li>Let |base:URL| be the <b>this</b> value's <a>relevant
                 settings object</a>'s [=environment settings object/api base


### PR DESCRIPTION
looks like [=dictionary member/present=] is no longer a thing? No defined in WebIDL anymore at least. 