### PR TITLE
chore: Clarify reason for choosing USVString

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,10 +293,11 @@
         </dl>
         <div class="note">
           These members are {{USVString}} (as opposed to {{DOMString}}) because
-          they are not allowed to contain invalid <a data-cite=
-          "rfc2781#section-2">UTF-16</a> surrogates. This means the user agent
-          is free to re-encode them in any Unicode encoding (e.g.,
-          <a data-cite="rfc3629#section-3">UTF-8</a>).
+          they are not allowed to contain surrogate code points. Among other
+          things, this means that the user agent can serialize them into any
+          Unicode encoding, such as <a data-cite="rfc3629#section-3">UTF-8</a>,
+          without change or loss of data or the generation of replacement
+          characters.
         </div>
         <div class="note">
           The {{ShareData/url}} member can contain a <a>relative-URL


### PR DESCRIPTION
We use USVString members as they are not allowed to contain
surrogate code points.

closes #152
