### PR TITLE
chore: export 'share target'

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,9 +312,9 @@
         Share targets
       </h2>
       <p>
-        A <dfn>share target</dfn> is the abstract concept of a destination that
-        the user agent will transmit the share data to. What constitutes a
-        share target is at the discretion of the user agent.
+        A <dfn data-export="">share target</dfn> is the abstract concept of a
+        destination that the user agent will transmit the share data to. What
+        constitutes a share target is at the discretion of the user agent.
       </p>
       <p>
         A share target might not be directly able to accept a {{ShareData}}


### PR DESCRIPTION
Export 'share target' so it can be referenced from the Share Target spec. 

When we eventually move Share Target to the WebApps WG, it might be preferable for the normative definition of a "share target" to live in the Share Target spec. 