### PR TITLE
chore(ci): use the spec-prod GitHub action

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate-and-publish:
     name: Validate and Publish
-    runs-on: ubuntu-latest # only linux supported at present
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: sidvishnoi/spec-prod@v1

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,9 +12,8 @@ jobs:
     runs-on: ubuntu-latest # only linux supported at present
     steps:
       - uses: actions/checkout@v2
-      - uses: w3c/respec-w3c-auto-publish@v1 # use the action
+      - uses: sidvishnoi/spec-prod@v1
         with:
-          ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          ECHIDNA_MANIFEST_URL: "https://w3c.github.io/web-share/ECHIDNA"
-          WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
-          CC: "${{ secrets.CC }}"
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
+          W3C_NOTIFICATIONS_CC: ${{ secrets.CC }}


### PR DESCRIPTION
We plan to deprecate [respec-w3c-auto-publish](https://github.com/w3c/respec-w3c-auto-publish) action in favor of a more generic [`spec-prod`](https://github.com/sidvishnoi/spec-prod/) action. The newer action is more consistent and requires fewer inputs.