### PR TITLE
Check transient activation after sharePromise

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,9 @@
             permission, return [=a promise rejected with=] with a
             {{"NotAllowedError"}} {{DOMException}}.
             </li>
+            <li>If {{[[sharePromise]]}} is not `null`, return <a>a promise
+            rejected with</a> {{InvalidStateError}}.
+            </li>
             <li>Let |window| be [=relevant global object=] of [=this=].
             </li>
             <li>If |window| does not have [=transient activation=], return [=a
@@ -157,9 +160,6 @@
             {{DOMException}}.
             </li>
             <li>[=Consume user activation=] of |window|.
-            </li>
-            <li>If {{[[sharePromise]]}} is not `null`, return <a>a promise
-            rejected with</a> {{InvalidStateError}}.
             </li>
             <li>If none of |data|'s members {{ShareData/title}},
             {{ShareData/text}}, or {{ShareData/url}} or {{ShareData/file}} are


### PR DESCRIPTION
WPT [web-share/share-sharePromise-internal-slot.https.html](https://github.com/web-platform-tests/wpt/commit/785685cf0921672462da96e99e7)
has multiple `navigator.share()` calls within a single
`onclick` handler. This is a good way to test the sharePromise
internal slot, but it was not previously permitted by the spec,
as the first call would consume activation and the later calls
would fail with `NotAllowedError` instead of `InvalidStateError`.

For *normative* changes, the following tasks have been completed:

 * [X] Newly consistent with Web platform tests ([test](https://github.com/web-platform-tests/wpt/commit/785685cf0921672462da96e99e7))

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [X] Chromium (https://chromium-review.googlesource.com/c/chromium/src/+/2427944)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
