### PR TITLE
Introduce canShareFiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,15 +103,21 @@
         </h3>
         <pre class="idl">
           partial interface Navigator {
+            [SecureContext] boolean canShareFiles(sequence&lt;USVString&gt; file_types);
             [SecureContext] Promise&lt;undefined&gt; share(optional ShareData data = {});
           };
         </pre>
         <p>
           User agents that do not support sharing SHOULD NOT expose
-          {{Navigator/share()}} on the {{Navigator}} interface.
+          {{Navigator/canShareFiles()}} or {{Navigator/share()}} on the
+          {{Navigator}} interface.
+        </p>
+        <p>
+          User agents that do not support file sharing SHOULD NOT expose
+          {{Navigator/canShareFiles()}} on the {{Navigator}} interface.
         </p>
         <div class="note">
-          The above statement is designed to permit feature detection. If
+          The above statements are designed to permit feature detection. If
           {{Navigator/share()}} is present, there is a reasonable expectation
           that it will work and present the user with at least one <a>share
           target</a>. Clients can use the presence or absence of this method to
@@ -137,6 +143,25 @@
           </dl>
         </section>
         <section>
+          <h4>
+            <dfn>canShareFiles()</dfn> method
+          </h4>
+          <p>
+            Each user agent should have an `allowlist` of permitted MIME types
+            and file extensions or file names. These may contain wildcards, for
+            example `*.txt` or `text/*`.
+          </p>
+          <p>
+            When the {{Navigator/canShareFiles()}} method is called with
+            argument |file_types|, run the following steps:
+          </p>
+          <ol class="algorithm">
+            <li>For each |file_type| in |file_types|, if |file_type| does not
+            match any entry in the user agent's `allowlist`, return `false`.
+            </li>
+            <li>Otherwise, return `true`.
+            </li>
+          </ol>
           <h4>
             <dfn>share()</dfn> method
           </h4>
@@ -194,9 +219,10 @@
                 </li>
               </ol>
             </li>
-            <li>If a file type is being blocked due to security considerations,
-            return <a>a promise rejected with</a> with a {{"NotAllowedError"}}
-            {{DOMException}}.
+            <li>If |data|'s {{ShareData/files}} member is present and
+            {{Navigator/canShareFiles()}} returns false when called with the
+            files' extensions and content types, return <a>a promise rejected
+            with</a> with a {{"NotAllowedError"}} {{DOMException}}.
             </li>
             <li>Set {{[[sharePromise]]}} to be <a>a new promise</a>.
             </li>
@@ -508,8 +534,7 @@
             when information should be confidential, so forwarding any content
             presents a risk. In particular, the {{ShareData/title}} might be
             used by an attacker to trick a user into misinterpreting the nature
-            of the content.
-            <!--
+            of the content. <!--
               , as demonstrated in the [[Wylecial]] <a data-cite=
               "Wylecial#">proof of concept attack</a>
             -->


### PR DESCRIPTION
Note: I am not sure of the best way to word the definition.

This is an incomplete early draft seeking feedback.



For *normative* changes, the following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share/pull/184.html" title="Last updated on Aug 9, 2021, 1:45 AM UTC (568ceb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/184/828058d...ewilligers:568ceb7.html" title="Last updated on Aug 9, 2021, 1:45 AM UTC (568ceb7)">Diff</a>