### PR TITLE
Demo: Disable buttons during share

### DIFF
--- a/demos/share-files.html
+++ b/demos/share-files.html
@@ -69,6 +69,11 @@
       logText(message, true);
     }
 
+    function setShareButtonsEnabled(enabled) {
+      document.querySelector('#share').disabled = !enabled;
+      document.querySelector('#share-no-gesture').disabled = !enabled;
+    }
+
     function checkboxChanged(e) {
       const checkbox = e.target;
       const textfield = document.querySelector('#' + checkbox.id.split('_')[0]);
@@ -79,11 +84,6 @@
     }
 
     async function testWebShare() {
-      if (navigator.share === undefined) {
-        logError('Error: Unsupported feature: navigator.share()');
-        return;
-      }
-
       const title_input = document.querySelector('#title');
       const text_input = document.querySelector('#text');
       const url_input = document.querySelector('#url');
@@ -97,19 +97,23 @@
       if (files && files.length > 0) {
         if (!navigator.canShare || !navigator.canShare({files})) {
           logError('Error: Unsupported feature: navigator.canShare()');
+          setShareButtonsEnabled(true);
           return;
         }
       }
 
+      setShareButtonsEnabled(false);
       try {
         await navigator.share({files, title, text, url});
         logText('Successfully sent share');
       } catch (error) {
         logError('Error sharing: ' + error);
       }
+      setShareButtonsEnabled(true);
     }
 
     async function testWebShareDelay() {
+      setShareButtonsEnabled(false);
       await sleep(6000);
       testWebShare();
     }
@@ -128,6 +132,7 @@
           testWebShareDelay);
 
       if (navigator.share === undefined) {
+        setShareButtonsEnabled(false);
         if (window.location.protocol === 'http:') {
           // navigator.share() is only available in secure contexts.
           window.location.replace(window.location.href.replace(/^http:/, 'https:'));

--- a/demos/share.html
+++ b/demos/share.html
@@ -65,6 +65,11 @@
       logText(message, true);
     }
 
+    function setShareButtonsEnabled(enabled) {
+      document.querySelector('#share').disabled = !enabled;
+      document.querySelector('#share-no-gesture').disabled = !enabled;
+    }
+
     function checkboxChanged(e) {
       const checkbox = e.target;
       const textfield = document.querySelector('#' + checkbox.id.split('_')[0]);
@@ -75,11 +80,6 @@
     }
 
     async function testWebShare() {
-      if (navigator.share === undefined) {
-        logError('Error: Unsupported feature: navigator.share');
-        return;
-      }
-
       const title_input = document.querySelector('#title');
       const text_input = document.querySelector('#text');
       const url_input = document.querySelector('#url');
@@ -87,15 +87,18 @@
       const title = title_input.disabled ? undefined : title_input.value;
       const text = text_input.disabled ? undefined : text_input.value;
       const url = url_input.disabled ? undefined : url_input.value;
+      setShareButtonsEnabled(false);
       try {
         await navigator.share({title, text, url});
         logText('Successfully sent share');
       } catch (error) {
         logError('Error sharing: ' + error);
       }
+      setShareButtonsEnabled(true);
     }
 
     async function testWebShareDelay() {
+      setShareButtonsEnabled(false);
       await sleep(6000);
       testWebShare();
     }
@@ -114,6 +117,7 @@
           testWebShareDelay);
 
       if (navigator.share === undefined) {
+        setShareButtonsEnabled(false);
         if (window.location.protocol === 'http:') {
           // navigator.share() is only available in secure contexts.
           window.location.replace(window.location.href.replace(/^http:/, 'https:'));


### PR DESCRIPTION
While the promise has not yet resolved or rejected, we disable
the share button to prevent additional share attempts.

This avoids confusion arising from
[[sharePromise]] internal slot (#113)

