### PR TITLE
chore: Remove references to WICG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ in designing the feature, you can remove yourself with the above syntax.
 # Style guide to contributors
 
 - the spec uses [ReSpec](https://www.w3.org/respec/)
-- the spec is tidied using [HTML5 Tidy](https://github.com/w3c/tidy-html5). For
+- the spec is tidied using [HTML5 Tidy](https://github.com/htacg/tidy-html5). For
   instructions on running HTML5 tidy, see below.
 - put comments in front of sections, for better readability with
   syntax coloring editors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
-# Web Platform Incubator Community Group
+# Web Applications Working Group
 
-This repository is being used for work in the W3C Web Platform Incubator
-Community Group, governed by the [W3C Community License Agreement
-(CLA)](http://www.w3.org/community/about/agreements/cla/). To make substantive
-contributions, you must join the CG.
+Contributions to this repository are intended to become part of Recommendation-track documents governed by the
+[W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software). To make substantive contributions to specifications, you must either participate
+in the relevant W3C Working Group or make a non-member patent licensing commitment.
+
+# Pull Requests
 
 If you are not the sole contributor to a contribution (pull request), please
 identify all contributors in the pull request comment.
@@ -23,3 +25,27 @@ If you added a contributor by mistake, you can remove them in a comment with:
 
 If you are making a pull request on behalf of someone else but you had no part
 in designing the feature, you can remove yourself with the above syntax.
+
+# Style guide to contributors
+
+- the spec uses [ReSpec](https://www.w3.org/respec/)
+- the spec is tidied using [HTML5 Tidy](https://github.com/w3c/tidy-html5). For
+  instructions on running HTML5 tidy, see below.
+- put comments in front of sections, for better readability with
+  syntax coloring editors.
+
+# Running HTML5 Tidy
+
+Please make sure you have HTML5 tidy installed, instead of
+the the one that ships with \*nix systems. You can comfirm this by running:
+
+```bash
+tidy --version  #HTML Tidy for HTML5 (experimental) for ...
+```
+
+Once you have confirmed (make sure you have committed your changes before
+running tidy, as the changes are destructive ... in a good way:)):
+
+```bash
+tidy -config tidyconfig.txt -o index.html index.html
+```

--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ navigator.share({title: 'Example Page', url: 'https://example.com'});
 
 ## Implementation status
 
-* The API is shipping in:
-  * Google Chrome 61 on Android.
-  * [Safari 66](https://developer.apple.com/safari/technology-preview/release-notes/#r66).
-  * Firefox Android coming soon.
+The API is shipping in [numerous browsers](https://caniuse.com/web-share).
 
 ## Links
 

--- a/demos/index.html
+++ b/demos/index.html
@@ -1,16 +1,25 @@
 <!-- This work is licensed under the W3C Software and Document License
      (http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
   -->
+<!DOCTYPE html>
 <html>
-<head>
-  <title>Web Share Demos</title>
-  <meta name="viewport" content="width=device-width">
-</head>
-<body>
-  <h1>Web Share Demos</h1>
-  <ul>
-    <li><a href="share.html">share</a></li>
-    <li><a href="share-files.html">share files (level 2)</a></li>
-  </ul>
-</body>
+  <head>
+    <title>
+      Web Share Demos
+    </title>
+    <meta name="viewport" content="width=device-width">
+  </head>
+  <body>
+    <h1>
+      Web Share Demos
+    </h1>
+    <ul>
+      <li>
+        <a href="share.html">share</a>
+      </li>
+      <li>
+        <a href="share-files.html">share files (level 2)</a>
+      </li>
+    </ul>
+  </body>
 </html>

--- a/demos/share-files.html
+++ b/demos/share-files.html
@@ -1,49 +1,89 @@
 <!-- This work is licensed under the W3C Software and Document License
      (http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
   -->
+<!DOCTYPE html>
 <html>
-<head>
-  <title>Web Share Test</title>
-  <meta name="viewport" content="width=device-width">
-  <style>
+  <head>
+    <title>
+      Web Share Test
+    </title>
+    <meta name="viewport" content="width=device-width">
+    <style>
     .error {
       color: #d22;
     }
     input[type="button"] {
         height: 30px
     }
-  </style>
-</head>
-<body>
-  <h1>Web Share Test</h1>
-  <table>
-    <tr><td>Title:</td>
-        <td><input type="checkbox" id="title_checkbox" checked/></td>
-        <td><input id="title" value="The Title" size="40" /></td>
-    </tr>
-    <tr><td>Text:</td>
-        <td><input type="checkbox" id="text_checkbox" checked/></td>
-        <td><input id="text" value="The message" size="40"/></td>
-    </tr>
-    <tr><td>URL:</td>
-        <td><input type="checkbox" id="url_checkbox" checked/></td>
-        <td><input id="url" value="https://example.com" size="40"/></td>
-    </tr>
-    <tr><td>Files:</td>
-        <td><!--Without column 2, the whole table is small on mobile.--></td>
-        <td><input id="files" type="file" multiple></td>
-    </tr>
-  </table>
-  <p><input id="share" type="button" value="Share" />
-     <input id="share-no-gesture" type="button" value="Share without user gesture" /></p>
-  <div id="output"></div>
-  <p>This is a test page for the <a href="https://github.com/WICG/web-share/tree/master/level-2">Web
-  Share API - Level 2, demonstrating file sharing</a>. It only works in browsers that have implemented the draft
-  proposal. At the time of writing, this works with:</p>
-  <ul>
-    <li>Google Chrome for Android 75 or higher.</li>
-  </ul>
-  <script>
+    </style>
+  </head>
+  <body>
+    <h1>
+      Web Share Test
+    </h1>
+    <table>
+      <tr>
+        <td>
+          Title:
+        </td>
+        <td>
+          <input type="checkbox" id="title_checkbox" checked>
+        </td>
+        <td>
+          <input id="title" value="The Title" size="40">
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Text:
+        </td>
+        <td>
+          <input type="checkbox" id="text_checkbox" checked>
+        </td>
+        <td>
+          <input id="text" value="The message" size="40">
+        </td>
+      </tr>
+      <tr>
+        <td>
+          URL:
+        </td>
+        <td>
+          <input type="checkbox" id="url_checkbox" checked>
+        </td>
+        <td>
+          <input id="url" value="https://example.com" size="40">
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Files:
+        </td>
+        <td>
+          <!--Without column 2, the whole table is small on mobile.-->
+        </td>
+        <td>
+          <input id="files" type="file" multiple>
+        </td>
+      </tr>
+    </table>
+    <p>
+      <input id="share" type="button" value="Share"> <input id=
+      "share-no-gesture" type="button" value="Share without user gesture">
+    </p>
+    <div id="output"></div>
+    <p>
+      This is a test page for the <a href=
+      "https://github.com/WICG/web-share/tree/master/level-2">Web Share API -
+      Level 2, demonstrating file sharing</a>. It only works in browsers that
+      have implemented the draft proposal. At the time of writing, this works
+      with:
+    </p>
+    <ul>
+      <li>Google Chrome for Android 75 or higher.
+      </li>
+    </ul>
+    <script>
     'use strict';
 
     function sleep(delay) {
@@ -144,6 +184,6 @@
     }
 
     window.addEventListener('load', onLoad);
-  </script>
-</body>
+    </script>
+  </body>
 </html>

--- a/demos/share-files.html
+++ b/demos/share-files.html
@@ -74,15 +74,10 @@
     <div id="output"></div>
     <p>
       This is a test page for the <a href=
-      "https://github.com/WICG/web-share/tree/master/level-2">Web Share API -
-      Level 2, demonstrating file sharing</a>. It only works in browsers that
-      have implemented the draft proposal. At the time of writing, this works
-      with:
+      "https://w3c.github.io/web-share/">Web Share API</a>, demonstrating
+      <a href="https://w3c.github.io/web-share/#dom-sharedata-files">file</a>
+      sharing. It only works in browsers that have implemented file sharing.
     </p>
-    <ul>
-      <li>Google Chrome for Android 75 or higher.
-      </li>
-    </ul>
     <script>
     'use strict';
 

--- a/demos/share.html
+++ b/demos/share.html
@@ -1,45 +1,77 @@
 <!-- This work is licensed under the W3C Software and Document License
      (http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
   -->
+<!DOCTYPE html>
 <html>
-<head>
-  <title>Web Share Test</title>
-  <meta name="viewport" content="width=device-width">
-  <style>
+  <head>
+    <title>
+      Web Share Test
+    </title>
+    <meta name="viewport" content="width=device-width">
+    <style>
     .error {
       color: #d22;
     }
     input[type="button"] {
         height: 30px
     }
-  </style>
-</head>
-<body>
-  <h1>Web Share Test</h1>
-  <table>
-    <tr><td>Title:</td>
-        <td><input type="checkbox" id="title_checkbox" checked/></td>
-        <td><input id="title" value="The Title" size="40" /></td>
-    </tr>
-    <tr><td>Text:</td>
-        <td><input type="checkbox" id="text_checkbox" checked/></td>
-        <td><input id="text" value="The message" size="40"/></td>
-    </tr>
-    <tr><td>URL:</td>
-        <td><input type="checkbox" id="url_checkbox" checked/></td>
-        <td><input id="url" value="https://example.com" size="40"/></td>
-    </tr>
-  </table>
-  <p><input id="share" type="button" value="Share" />
-     <input id="share-no-gesture" type="button" value="Share without user gesture" /></p>
-  <div id="output"></div>
-  <p>This is a test page for the <a href="https://github.com/WICG/web-share">Web
-  Share API</a>. It will only work in browsers that have implemented the draft
-  proposal. At the time of writing, this works with:</p>
-  <ul>
-    <li>Google Chrome for Android 61 or higher.</li>
-  </ul>
-  <script>
+    </style>
+  </head>
+  <body>
+    <h1>
+      Web Share Test
+    </h1>
+    <table>
+      <tr>
+        <td>
+          Title:
+        </td>
+        <td>
+          <input type="checkbox" id="title_checkbox" checked>
+        </td>
+        <td>
+          <input id="title" value="The Title" size="40">
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Text:
+        </td>
+        <td>
+          <input type="checkbox" id="text_checkbox" checked>
+        </td>
+        <td>
+          <input id="text" value="The message" size="40">
+        </td>
+      </tr>
+      <tr>
+        <td>
+          URL:
+        </td>
+        <td>
+          <input type="checkbox" id="url_checkbox" checked>
+        </td>
+        <td>
+          <input id="url" value="https://example.com" size="40">
+        </td>
+      </tr>
+    </table>
+    <p>
+      <input id="share" type="button" value="Share"> <input id=
+      "share-no-gesture" type="button" value="Share without user gesture">
+    </p>
+    <div id="output"></div>
+    <p>
+      This is a test page for the <a href=
+      "https://github.com/WICG/web-share">Web Share API</a>. It will only work
+      in browsers that have implemented the draft proposal. At the time of
+      writing, this works with:
+    </p>
+    <ul>
+      <li>Google Chrome for Android 61 or higher.
+      </li>
+    </ul>
+    <script>
     'use strict';
 
     function sleep(delay) {
@@ -129,6 +161,6 @@
     }
 
     window.addEventListener('load', onLoad);
-  </script>
-</body>
+    </script>
+  </body>
 </html>

--- a/demos/share.html
+++ b/demos/share.html
@@ -63,14 +63,9 @@
     <div id="output"></div>
     <p>
       This is a test page for the <a href=
-      "https://github.com/WICG/web-share">Web Share API</a>. It will only work
-      in browsers that have implemented the draft proposal. At the time of
-      writing, this works with:
+      "https://w3c.github.io/web-share/">Web Share API</a>. It will only work
+      in browsers that have implemented the API.
     </p>
-    <ul>
-      <li>Google Chrome for Android 61 or higher.
-      </li>
-    </ul>
     <script>
     'use strict';
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -13,7 +13,7 @@ project](https://github.com/chromium/ballista), which aims to explore
 website-to-website and website-to-native interoperability.
 
 See also:
-* [Specification](https://wicg.github.io/web-share/), the formal draft spec.
+* [Specification](https://w3c.github.io/web-share/), the formal draft spec.
 * [Native integration survey](native.md), for platform-specific matters.
 
 ## User flow

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -3,7 +3,7 @@
 **Date**: 2017-05-02
 
 The interface for Web Share is now described at
-[https://wicg.github.io/web-share/](https://wicg.github.io/web-share/).
+[https://w3c.github.io/web-share/](https://w3c.github.io/web-share/).
 
 The basic Share API only allows share requests to be sent (this API does not
 provide the capability to receive share requests). For a follow-up plan to have

--- a/index.html
+++ b/index.html
@@ -393,7 +393,7 @@
         <div class="note">
           There is an attempt to standardize the registration of websites to
           receive share data for that final use case; see <a href=
-          "https://github.com/WICG/web-share-target">Web Share Target</a>.
+          "https://github.com/w3c/web-share-target">Web Share Target</a>.
         </div>
         <p>
           In some cases, the host operating system will provide a sharing or


### PR DESCRIPTION
Remove references to WICG
    
Web Share API is now developed in Web Applications Working Group.
    
Add style guide explaining use of HTML Tidy.
   
Link to https://caniuse.com/web-share for current
information about implementation support.
