### PR TITLE
fix: canShare() return false if not allowed to use

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,9 @@
             </li>
             <li>If |document| is not [=Document/fully active=], return false.
             </li>
+            <li>If |document| is not <a>allowed to use</a> <a>"web-share"</a>,
+            return `false`.
+            </li>
             <li>Return the result of [=validate share data=] with |data| and
             [=this=]'s [=relevant settings object=]'s [=environment settings
             object/API base URL=].

--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
             <li>If |document| is not [=Document/fully active=], return false.
             </li>
             <li>If |document| is not <a>allowed to use</a> <a>"web-share"</a>,
-            return `false`.
+            return false.
             </li>
             <li>Return the result of [=validate share data=] with |data| and
             [=this=]'s [=relevant settings object=]'s [=environment settings


### PR DESCRIPTION
For *normative* changes, the following tasks have been completed:

 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/30868)

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=214448)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1251175)
 * [x] Gecko (https://phabricator.services.mozilla.com/D90834)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/pull/220.html" title="Last updated on Sep 20, 2021, 10:35 PM UTC (9a32b1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/220/94e7883...9a32b1d.html" title="Last updated on Sep 20, 2021, 10:35 PM UTC (9a32b1d)">Diff</a>