### PR TITLE
Editorial: use global task to resolve promises

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,12 +188,12 @@
             return [=a promise rejected with=] an {{"InvalidStateError"}}
             {{DOMException}}.
             </li>
-            <li>Let |window| be [=relevant global object=] of [=this=].
+            <li>Let |global:Window| be [=this=]'s [=relevant global object=].
             </li>
-            <li>If |window| does not have [=transient activation=], return [=a
+            <li>If |global| does not have [=transient activation=], return [=a
             promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
             </li>
-            <li>[=Consume user activation=] of |window|.
+            <li>[=Consume user activation=] of |global|.
             </li>
             <li>Let |base:URL| be [=this=]'s <a>relevant settings object</a>'s
             [=environment settings object/API base URL=].
@@ -226,11 +226,10 @@
               <ol>
                 <li>If there are no <a>share targets</a> available, [=queue a
                 global task=] on the [=user interaction task source=] using
-                [=this=]'s [=relevant global object=] to:
+                |global| to:
                   <ol>
-                    <li>
-                      [=Reject=] [=this=].{{Navigator/[[sharePromise]]}}
-                      with an {{"AbortError"}} {{DOMException}}.
+                    <li>[=Reject=] [=this=].{{Navigator/[[sharePromise]]}} with
+                    an {{"AbortError"}} {{DOMException}}.
                     </li>
                     <li>Set [=this=].{{Navigator/[[sharePromise]]}} to `null`.
                     </li>
@@ -245,7 +244,7 @@
                 </li>
                 <li>If the user chose to cancel the share operation, [=queue a
                 global task=] on the [=user interaction task source=] using
-                [=this=]'s [=relevant global object=] to:
+                |global| to:
                   <ol>
                     <li>[=Reject=] [=this=].{{Navigator/[[sharePromise]]}} with
                     an {{"AbortError"}} {{DOMException}},
@@ -262,7 +261,7 @@
                 </li>
                 <li>If an error occurs starting the target or transmitting the
                 data, [=queue a global task=] on the [=user interaction task
-                source=] using [=this=]'s [=relevant global object=] to:
+                source=] using |global| to:
                   <ol>
                     <li>[=Reject=] [=this=].{{Navigator/[[sharePromise]]}} with
                     an {{"DataError"}} {{DOMException}}.
@@ -277,7 +276,7 @@
                 the [=share target=], or successfully transmitted to the OS (if
                 the transmission to the [=share target=] cannot be confirmed),
                 [=queue a global task=] on the [=user interaction task source=]
-                using [=this=]'s [=relevant global object=] to:
+                using |global| to:
                   <ol>
                     <li>[=Resolve=] [=this=].{{Navigator/[[sharePromise]]}}
                     with `undefined`.

--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
                 [=this=]'s [=relevant global object=] to:
                   <ol>
                     <li>
-                      <a>Reject</a> [=this=].{{Navigator/[[sharePromise]]}}
+                      [=Reject=] [=this=].{{Navigator/[[sharePromise]]}}
                       with an {{"AbortError"}} {{DOMException}}.
                     </li>
                     <li>Set [=this=].{{Navigator/[[sharePromise]]}} to `null`.

--- a/index.html
+++ b/index.html
@@ -224,7 +224,9 @@
             <li>Return [=this=].{{Navigator/[[sharePromise]]}} and <a>in
             parallel</a>:
               <ol>
-                <li>If there are no <a>share targets</a> available:
+                <li>If there are no <a>share targets</a> available, [=queue a
+                global task=] on the [=user interaction task source=] using
+                [=this=]'s [=relevant global object=] to:
                   <ol>
                     <li>
                       <a>Reject</a> [=this=].{{Navigator/[[sharePromise]]}}
@@ -241,11 +243,12 @@
                 MUST be given the option to cancel rather than choosing any of
                 the share targets. Wait for the user's choice.
                 </li>
-                <li>If the user chose to cancel the share operation:
+                <li>If the user chose to cancel the share operation, [=queue a
+                global task=] on the [=user interaction task source=] using
+                [=this=]'s [=relevant global object=] to:
                   <ol>
-                    <li>
-                      <a>Reject</a> [=this=].{{Navigator/[[sharePromise]]}}
-                      with an {{"AbortError"}} {{DOMException}},
+                    <li>[=Reject=] [=this=].{{Navigator/[[sharePromise]]}} with
+                    an {{"AbortError"}} {{DOMException}},
                     </li>
                     <li>Set [=this=].{{Navigator/[[sharePromise]]}} to `null`.
                     </li>
@@ -258,11 +261,11 @@
                 transmit the converted data to the target.
                 </li>
                 <li>If an error occurs starting the target or transmitting the
-                data:
+                data, [=queue a global task=] on the [=user interaction task
+                source=] using [=this=]'s [=relevant global object=] to:
                   <ol>
-                    <li>
-                      <a>Reject</a> [=this=].{{Navigator/[[sharePromise]]}}
-                      with an {{"DataError"}} {{DOMException}}.
+                    <li>[=Reject=] [=this=].{{Navigator/[[sharePromise]]}} with
+                    an {{"DataError"}} {{DOMException}}.
                     </li>
                     <li>Set [=this=].{{Navigator/[[sharePromise]]}} to `null`.
                     </li>
@@ -273,10 +276,15 @@
                 <li>Once the data has either been successfully transmitted to
                 the [=share target=], or successfully transmitted to the OS (if
                 the transmission to the [=share target=] cannot be confirmed),
-                <a>resolve</a> [=this=].{{Navigator/[[sharePromise]]}} with
-                `undefined`.
-                </li>
-                <li>Set [=this=].{{Navigator/[[sharePromise]]}} to `null`.
+                [=queue a global task=] on the [=user interaction task source=]
+                using [=this=]'s [=relevant global object=] to:
+                  <ol>
+                    <li>[=Resolve=] [=this=].{{Navigator/[[sharePromise]]}}
+                    with `undefined`.
+                    </li>
+                    <li>Set [=this=].{{Navigator/[[sharePromise]]}} to `null`.
+                    </li>
+                  </ol>
                 </li>
               </ol>
             </li>


### PR DESCRIPTION
Closes #235

Editorial fix-up of what we originally intended. Doesn't affect UA behavior is and shouldn't be observable/testable (AFAIK).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 27, 2022, 7:07 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fweb-share%2Fc1e3ac98a686aa46f3fd9fdb59ba9c6ed871da8a%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/flncu8
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/web-share%23236.)._
</details>
