### PR TITLE
Filter out zero length files

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,8 +345,8 @@
               <ol>
                 <li>For each |file:File| in {{ShareData/files}}:
                   <ol>
-                    <li>If |file| has {{File/length}} equal to 0, remove |file|
-                    from {{ShareData/files}}.
+                    <li>If |file|'s {{File/length}} is 0, remove |file| from
+                    {{ShareData/files}}.
                     </li>
                   </ol>
                 </li>

--- a/index.html
+++ b/index.html
@@ -343,6 +343,13 @@
             </li>
             <li>If |data|'s {{ShareData/files}} member is present:
               <ol>
+                <li>For each |file:File| in {{ShareData/files}}:
+                  <ol>
+                    <li>If |file| has {{File/length}} is 0, remove |file| from
+                    {{ShareData/files}}.
+                    </li>
+                  </ol>
+                </li>
                 <li>If |titleTextOrUrl| is false and |data|'s
                 {{ShareData/files}} member is empty, return false.
                   <p class="note">

--- a/index.html
+++ b/index.html
@@ -345,8 +345,8 @@
               <ol>
                 <li>For each |file:File| in {{ShareData/files}}:
                   <ol>
-                    <li>If |file| has {{File/length}} is 0, remove |file| from
-                    {{ShareData/files}}.
+                    <li>If |file| has {{File/length}} equal to 0, remove |file|
+                    from {{ShareData/files}}.
                     </li>
                   </ol>
                 </li>

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
               <ol>
                 <li>For each |file:File| in {{ShareData/files}}:
                   <ol>
-                    <li>If |file|'s {{File/length}} is 0, remove |file| from
+                    <li>If |file|'s {{Blob/size}} is 0, remove |file| from
                     {{ShareData/files}}.
                     </li>
                   </ol>


### PR DESCRIPTION
Closes #229

For *normative* changes, the following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 30, 2022, 3:36 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fweb-share%2F66f7a99550f06fb5555c1ba52b2909ce7b8ad8e3%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/Y3yDqN
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/web-share%23237.)._
</details>
