### PR TITLE
Editorial: remove Extensibility text

### DIFF
--- a/index.html
+++ b/index.html
@@ -704,56 +704,6 @@
         </li>
       </ul>
     </section>
-    <section class="appendix informative">
-      <h2>
-        Extensibility of this API
-      </h2>
-      <p>
-        The Web Share API is designed to be extended in the future by way of
-        new members added to the {{ShareData}} dictionary, to allow both
-        sharing of new types of data (<i>e.g.</i>, <a href=
-        "https://github.com/w3c/web-share/issues/12">images</a>) and strings
-        with new semantics (<i>e.g.</i> author).
-      </p>
-      <div class="warning">
-        This doesn't mean user agents can add whatever members they like. It
-        means that new members can be added to the standard in the future.
-      </div>
-      <p>
-        The three members {{ShareData/title}}, {{ShareData/text}}, and
-        {{ShareData/url}}, are part of the base feature set, and
-        implementations that provide {{Navigator/share()}} need to accept all
-        three. Any new members that are added in the future will be
-        <em>individually feature-detectable</em>, to allow for
-        backwards-compatibility with older implementations that don't recognize
-        those members. These new members might also be added as optional "MAY"
-        requirements.
-      </p>
-      <div class="note">
-        There is <a href="https://github.com/heycam/webidl/issues/107">an open
-        discussion</a> about how to provide feature-detection for dictionary
-        members. Web Share will use the mechanism produced by that discussion.
-      </div>
-      <p>
-        The {{Navigator/share()}} method returns a rejected promise with a
-        {{TypeError}} if none of the specified members are present. The
-        intention is that when a new member is added, it will also be added to
-        this list of recognized members. This is for future-proofing
-        implementations: if a web site written against a future version of this
-        spec uses <em>only</em> new members (<i>e.g.</i>,
-        `navigator.share({image: x})`), it will be valid in future user agents,
-        but a {{TypeError}} on user agents implementing an older version of the
-        spec. Developers will be asked to feature-detect any new members they
-        rely on, to avoid having errors surface in their program.
-      </p>
-      <p>
-        Editors of this spec will want to carefully consider the genericity of
-        any new members being added, avoiding members that are closely
-        associated with a particular service, user agent or operating system,
-        in favour of members that can potentially be applied to a wide range of
-        platforms and targets.
-      </p>
-    </section>
     <section id="conformance"></section>
     <section id="idl-index"></section>
     <section class="informative">


### PR DESCRIPTION
Closes #61 

In light of #108, I think we should remove this. 

Example of how developers find what is supported was part of #238.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/pull/239.html" title="Last updated on Jul 7, 2022, 5:13 AM UTC (3b15c9d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/239/c33c7af...3b15c9d.html" title="Last updated on Jul 7, 2022, 5:13 AM UTC (3b15c9d)">Diff</a>