### PR TITLE
Editorial: cleanup notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,7 +497,7 @@
             A URL string referring to a resource being shared.
           </dd>
         </dl>
-        <aside class="note">
+        <aside class="note" data-cite="encoding">
           These members are {{USVString}} (as opposed to {{DOMString}}) because
           they are not allowed to contain surrogate code points. Among other
           things, this means that the user agent can serialize them into any

--- a/index.html
+++ b/index.html
@@ -497,20 +497,13 @@
             A URL string referring to a resource being shared.
           </dd>
         </dl>
-        <div class="note">
+        <aside class="note">
           These members are {{USVString}} (as opposed to {{DOMString}}) because
           they are not allowed to contain surrogate code points. Among other
           things, this means that the user agent can serialize them into any
-          Unicode encoding, such as <a data-cite="rfc3629#section-3">UTF-8</a>,
-          without change or loss of data or the generation of replacement
-          characters.
-        </div>
-        <div class="note">
-          The {{ShareData/url}} member can contain a <a>relative-URL
-          string</a>. In this case, it will be automatically resolved relative
-          to the current page location, just like a {{HTMLBaseElement/href}} on
-          an [^a^] element, before being given to the share target.
-        </div>
+          Unicode encoding, such as [=UTF-8=], without change or loss of data
+          or the generation of replacement characters.
+        </aside>
       </section>
     </section>
     <section>


### PR DESCRIPTION
Closes #65

Discussion of relative/absolute URL for the `url` member is covered in the Usage Examples section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/pull/241.html" title="Last updated on Jun 7, 2022, 6:06 AM UTC (e1701f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/241/45508be...e1701f6.html" title="Last updated on Jun 7, 2022, 6:06 AM UTC (e1701f6)">Diff</a>