### PR TITLE
chore: auto-publish as CRD

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -21,4 +21,4 @@ jobs:
           W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
           W3C_NOTIFICATIONS_CC: ${{ secrets.CC }}
           W3C_BUILD_OVERRIDE: |
-            specStatus: WD
+            specStatus: CRD


### PR DESCRIPTION
Enables publishing as Candidate Recommendation Draft after the we publish CR... which should happen later today. 