### PR TITLE
Explain example correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
         [^iframe/allow^] attribute:
       </p>
       <aside class="example" title=
-      "Disabling the web-share API in a third-party context">
+      "Enabling the web-share API in a third-party context">
         <pre class="html">
             &lt;iframe
               src="https://third-party.example"


### PR DESCRIPTION
The title didn't match what the example does.

using `allow` **enables** rather than **disables** the API in a 3rd-party iframe

Closes #262

Non-normative change (because it's an example).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chaals/web-share/pull/263.html" title="Last updated on Jan 4, 2023, 6:45 PM UTC (f0b72e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/263/98b6c0f...chaals:f0b72e9.html" title="Last updated on Jan 4, 2023, 6:45 PM UTC (f0b72e9)">Diff</a>