### PR TITLE
Make Permissions-Policy HTTP header OPTIONAL

### DIFF
--- a/index.html
+++ b/index.html
@@ -691,7 +691,7 @@
         to use=] the API by default.
       </p>
       <p>
-        It is OPTIONAL for user agents for user agents to support
+        It is OPTIONAL for user agents to support
         [[[PERMISSIONS-POLICY]]]'s `Permissions-Policy` HTTP header.
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -691,6 +691,10 @@
         to use=] the API by default.
       </p>
       <p>
+        It is OPTIONAL for user agents for user agents to support
+        [[[PERMISSIONS-POLICY]]]'s `Permissions-Policy` HTTP header.
+      </p>
+      <p>
         Developers can use the means afforded by the [[[permissions-policy]]]
         specification to control if and when a third-party context is [=allowed
         to use=] this API.
@@ -707,6 +711,11 @@
           Developers are advised to check the implementation status of the
           [[[Permissions-Policy]]] specification before relying on it to enable
           the Web Share API in third-party contexts.
+        </p>
+        <p>
+          The Working Group expects to make the `Permissions-Policy` HTTP
+          header mandatory in a future revisions of this specification, once
+          the header is more widely supported.
         </p>
       </aside>
     </section>

--- a/index.html
+++ b/index.html
@@ -703,7 +703,7 @@
         <p>
           Although user agents are unified in preventing the Web Share API from
           being used in third-party context, at the time of publication there
-          are interoperability with relying on the [[[Permissions-Policy]]] to
+          are interoperability issues with relying on the [[[Permissions-Policy]]] to
           enable the API in third-party contexts. In particular, although
           the[^iframe/allow^] attribute is widely supported, the updated syntax
           for the [^iframe/allow^] attribute is not. Similarly, the
@@ -713,9 +713,9 @@
           the Web Share API in third-party contexts.
         </p>
         <p>
-          The Working Group expects to make the `Permissions-Policy` HTTP
-          header mandatory in a future revisions of this specification, once
-          the header is more widely supported.
+          When the `Permissions-Policy` HTTP header is more widely supported, 
+          the Working Group expects to revise this specification 
+          to require support for the header.
         </p>
       </aside>
     </section>


### PR DESCRIPTION
CC @tantek - to address Formal Objection. 

For *normative* changes, the following tasks have been completed:

 * Web platform tests - learning the tests as they are, as eventually use agents should support the header. 

Implementation commitment:

 * [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=253126) does not yet implement the header. 
 * [x] Chromium - implemented
 * [ ] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1694922) - does not yet implement the header.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/pull/275.html" title="Last updated on Mar 1, 2023, 1:57 AM UTC (4c45203)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-share/275/7f78426...4c45203.html" title="Last updated on Mar 1, 2023, 1:57 AM UTC (4c45203)">Diff</a>